### PR TITLE
PlantUML: Avoid rendering out-of-view-scope elements in deployment views

### DIFF
--- a/structurizr-plantuml/src/com/structurizr/io/plantuml/C4PlantUMLWriter.java
+++ b/structurizr-plantuml/src/com/structurizr/io/plantuml/C4PlantUMLWriter.java
@@ -163,6 +163,9 @@ public class C4PlantUMLWriter extends PlantUMLWriter {
 		@Override
 		void doWrite(View view, SoftwareSystemInstance element, Writer writer, String prefix, String id, String separator)
 				throws IOException {
+			if (view.getElementView(element) == null) {
+					return;
+			}
 			boolean internal = !element.getSoftwareSystem().getLocation().equals(Location.External);
 			Type type = Type.valueOf(element.getProperties().getOrDefault(C4_ELEMENT_TYPE,
 					element.getSoftwareSystem().getProperties().getOrDefault(C4_ELEMENT_TYPE,Type.Default.name())

--- a/structurizr-plantuml/src/com/structurizr/io/plantuml/C4PlantUMLWriter.java
+++ b/structurizr-plantuml/src/com/structurizr/io/plantuml/C4PlantUMLWriter.java
@@ -180,6 +180,9 @@ public class C4PlantUMLWriter extends PlantUMLWriter {
 		@Override
 		void doWrite(View view, ContainerInstance element, Writer writer, String prefix, String id, String separator)
 				throws IOException {
+			if (view.getElementView(element) == null) {
+					return;
+			}
 			Type type = Type.valueOf(element.getProperties().getOrDefault(C4_ELEMENT_TYPE,
 					element.getContainer().getProperties().getOrDefault(C4_ELEMENT_TYPE,Type.Default.name())
 			));

--- a/structurizr-plantuml/src/com/structurizr/io/plantuml/PlantUMLWriter.java
+++ b/structurizr-plantuml/src/com/structurizr/io/plantuml/PlantUMLWriter.java
@@ -232,6 +232,9 @@ public class PlantUMLWriter extends AbstractPlantUMLWriter {
             List<ContainerInstance> containerInstances = new ArrayList<>(deploymentNode.getContainerInstances());
             containerInstances.sort(Comparator.comparing(ContainerInstance::getName));
             for (ContainerInstance containerInstance : containerInstances) {
+                if (view.getElementView(containerInstance) == null) {
+                    continue;
+                }
                 write(view, containerInstance, writer, indent+1);
             }
 

--- a/structurizr-plantuml/src/com/structurizr/io/plantuml/PlantUMLWriter.java
+++ b/structurizr-plantuml/src/com/structurizr/io/plantuml/PlantUMLWriter.java
@@ -214,18 +214,27 @@ public class PlantUMLWriter extends AbstractPlantUMLWriter {
             List<DeploymentNode> children = new ArrayList<>(deploymentNode.getChildren());
             children.sort(Comparator.comparing(DeploymentNode::getName));
             for (DeploymentNode child : children) {
+                if (view.getElementView(child) == null) {
+                    continue;
+                }
                 write(view, child, writer, indent + 1);
             }
 
             List<InfrastructureNode> infrastructureNodes = new ArrayList<>(deploymentNode.getInfrastructureNodes());
             infrastructureNodes.sort(Comparator.comparing(InfrastructureNode::getName));
             for (InfrastructureNode infrastructureNode : infrastructureNodes) {
+                if (view.getElementView(infrastructureNode) == null) {
+                    continue;
+                }
                 write(view, infrastructureNode, writer, indent+1);
             }
 
             List<SoftwareSystemInstance> softwareSystemInstances = new ArrayList<>(deploymentNode.getSoftwareSystemInstances());
             softwareSystemInstances.sort(Comparator.comparing(SoftwareSystemInstance::getName));
             for (SoftwareSystemInstance softwareSystemInstance : softwareSystemInstances) {
+                if (view.getElementView(softwareSystemInstance) == null) {
+                    continue;
+                }
                 write(view, softwareSystemInstance, writer, indent+1);
             }
 

--- a/structurizr-plantuml/src/com/structurizr/io/plantuml/StructurizrPlantUMLWriter.java
+++ b/structurizr-plantuml/src/com/structurizr/io/plantuml/StructurizrPlantUMLWriter.java
@@ -183,12 +183,18 @@ public class StructurizrPlantUMLWriter extends AbstractPlantUMLWriter {
             List<DeploymentNode> children = new ArrayList<>(deploymentNode.getChildren());
             children.sort(Comparator.comparing(DeploymentNode::getName));
             for (DeploymentNode child : children) {
+                if (view.getElementView(child) == null) {
+                    continue;
+                }
                 write(view, child, writer, indent + 1);
             }
 
             List<InfrastructureNode> infrastructureNodes = new ArrayList<>(deploymentNode.getInfrastructureNodes());
             infrastructureNodes.sort(Comparator.comparing(InfrastructureNode::getName));
             for (InfrastructureNode infrastructureNode : infrastructureNodes) {
+                if (view.getElementView(infrastructureNode) == null) {
+                    continue;
+                }
                 write(view, infrastructureNode, writer, indent+1);
             }
 
@@ -204,6 +210,9 @@ public class StructurizrPlantUMLWriter extends AbstractPlantUMLWriter {
             List<SoftwareSystemInstance> softwareSystemInstances = new ArrayList<>(deploymentNode.getSoftwareSystemInstances());
             softwareSystemInstances.sort(Comparator.comparing(SoftwareSystemInstance::getName));
             for (SoftwareSystemInstance softwareSystemInstance : softwareSystemInstances) {
+                if (view.getElementView(softwareSystemInstance) == null) {
+                    continue;
+                }
                 write(view, softwareSystemInstance, writer, indent+1);
             }
 

--- a/structurizr-plantuml/src/com/structurizr/io/plantuml/StructurizrPlantUMLWriter.java
+++ b/structurizr-plantuml/src/com/structurizr/io/plantuml/StructurizrPlantUMLWriter.java
@@ -195,6 +195,9 @@ public class StructurizrPlantUMLWriter extends AbstractPlantUMLWriter {
             List<ContainerInstance> containerInstances = new ArrayList<>(deploymentNode.getContainerInstances());
             containerInstances.sort(Comparator.comparing(ContainerInstance::getName));
             for (ContainerInstance containerInstance : containerInstances) {
+                if (view.getElementView(containerInstance) == null) {
+                    continue;
+                }
                 write(view, containerInstance, writer, indent+1);
             }
 

--- a/structurizr-plantuml/test/structurizr-54915-workspace.json
+++ b/structurizr-plantuml/test/structurizr-54915-workspace.json
@@ -2,12 +2,23 @@
     "id": 54915,
     "name": "Amazon Web Services Example",
     "description": "An example AWS deployment architecture.",
-    "revision": 39,
+    "revision": 40,
     "lastModifiedDate": "2020-06-29T11:07:28Z",
-    "lastModifiedUser": "simon",
-    "lastModifiedAgent": "structurizr-dotnet/0.9.6",
     "model": {
         "softwareSystems": [
+            {
+                "id": "18",
+                "tags": "Element,Software System",
+                "name": "Another System",
+                "location": "Unspecified",
+                "containers": [
+                    {
+                        "id": "19",
+                        "tags": "Element,Container",
+                        "name": "Another App"
+                    }
+                ]
+            },
             {
                 "id": "1",
                 "tags": "Element,Software System",
@@ -101,6 +112,14 @@
                                         "environment": "Default",
                                         "instances": 1,
                                         "containerInstances": [
+                                            {
+                                                "id": "20",
+                                                "tags": "Container Instance",
+                                                "environment": "Default",
+                                                "instanceId": 1,
+                                                "containerId": "19",
+                                                "properties": {}
+                                            },
                                             {
                                                 "id": "9",
                                                 "tags": "Container Instance",

--- a/structurizr-plantuml/test/structurizr-54915-workspace.json
+++ b/structurizr-plantuml/test/structurizr-54915-workspace.json
@@ -16,6 +16,11 @@
                         "id": "19",
                         "tags": "Element,Container",
                         "name": "Another App"
+                    },
+                    {
+                        "id": "20",
+                        "tags": "Element,Container,Database",
+                        "name": "App Database"
                     }
                 ]
             },
@@ -93,6 +98,25 @@
                                         ],
                                         "children": [],
                                         "infrastructureNodes": []
+                                    },
+                                    {
+                                        "id": "22",
+                                        "tags": "Element,Deployment Node,Amazon Web Services - RDS_PostgreSQL_instance",
+                                        "name": "PostgreSQL",
+                                        "environment": "Default",
+                                        "instances": 1,
+                                        "containerInstances": [
+                                            {
+                                                "id": "23",
+                                                "tags": "Container Instance",
+                                                "environment": "Default",
+                                                "containerId": "20",
+                                                "instanceId": 1,
+                                                "properties": {}
+                                            }
+                                        ],
+                                        "children": [],
+                                        "infrastructureNodes": []
                                     }
                                 ],
                                 "containerInstances": [],
@@ -113,7 +137,7 @@
                                         "instances": 1,
                                         "containerInstances": [
                                             {
-                                                "id": "20",
+                                                "id": "21",
                                                 "tags": "Container Instance",
                                                 "environment": "Default",
                                                 "instanceId": 1,


### PR DESCRIPTION
## Context

I noticed [this deployment view](https://structurizr.com/share/56937/diagrams#prisonerContentHubContainerProductionDeployment) renders differently than the PlantUML output (using the CLI@1.2.0).

The PlantUML version displays containers that are not in scope to the selected software system:

| Structurizr | PlantUML (before this PR) |
| --- | --- |
| ![Structurizr](https://user-images.githubusercontent.com/1526295/89785284-11a2d600-db12-11ea-9c76-866ad65dd0e7.png) | ![structurizr-56937-prisonerContentHubContainerProductionDeployment](https://user-images.githubusercontent.com/1526295/89785450-5b8bbc00-db12-11ea-8aa6-eb7dba92565c.png) |

After a bit of digging, I ended up here:

https://github.com/structurizr/java-extensions/blob/31f6230cdfd4e3728b684c24e9803da19dbb1fff/structurizr-plantuml/src/com/structurizr/io/plantuml/StructurizrPlantUMLWriter.java#L195-L199

As far as I can tell, it gets the list of containers from the deployment nodes and doesn't scope it to the system in the deployment view.

## What changed

The changeset modifies the workspace definition to add these relationships:

- Another System &rarr; Another App &rarr; existing EC2 deployment node
- Another System &rarr; App Database &rarr; new PostgreSQL RDS deployment node

This state failed the tests as the PlantUML output should not render out-of-scope deployment nodes or containers.

To fix the tests, I ended up filtering with `view.getElementView(element) == null` as a way to check "does the view contain this element" before rendering them.

I'm not sure if it's idiomatic, but all the tests pass now.

## New output

(Same workspace file, using `StructurizrPlantUMLWriter`)

<img src="https://user-images.githubusercontent.com/1526295/89789723-de177a00-db18-11ea-9fc8-843b49589df0.png" width="300" />