### PR TITLE
Improve documentation

### DIFF
--- a/docs/component-finder.md
+++ b/docs/component-finder.md
@@ -4,24 +4,29 @@ The Structurizr for Java library includes a component finder and a number of pre
 
 ## Background
 
-The idea behind the [C4 model](https://c4model.com) and Structurizr is that there are a number of levels of abstraction sitting above the code. Although we write Java code using interfaces and classes in packages, it's often useful to think about how that code is organised into "components". In its simplest form, a "component" is just a grouping of classes and interfaces.
+The idea behind the [C4 model](https://c4model.com) and Structurizr is that there are a number of levels of abstraction sitting above the code.
+Although we write Java code using interfaces and classes in packages, it's often useful to think about how that code is organised into "components".
+In its simplest form, a "component" is just a grouping of classes and interfaces.
 
-If you reverse-engineer some Java code using a UML tool, you'll typically get a UML class diagram showing all of the classes and interfaces. The component diagram in the C4 model is about hiding some of this complexity and implementation detail. You can read more about this at [Components vs classes](https://structurizr.com/help/components-vs-classes).
+If you reverse-engineer some Java code using a UML tool, you'll typically get a UML class diagram showing all of the classes and interfaces.
+The component diagram in the C4 model is about hiding some of this complexity and implementation detail.
+You can read more about this at [Components vs classes](https://structurizr.com/help/components-vs-classes).
 
 ## Purpose
 
-The purpose of the [component finder](https://github.com/structurizr/java/blob/master/structurizr-core/src/com/structurizr/analysis/ComponentFinder.java) is to find components in your codebase. Since every codebase is different (i.e. code structure, naming conventions, frameworks used, etc), different pluggable component finder strategies allow you to customize the rules that you use to find components.
+The purpose of the [component finder](https://github.com/structurizr/java-extensions/blob/master/structurizr-analysis/src/com/structurizr/analysis/ComponentFinder.java) is to find components in your codebase.
+Since every codebase is different (i.e. code structure, naming conventions, frameworks used, etc), different pluggable component finder strategies allow you to customize the rules that you use to find components.
 Some example rules that you might use to find components include:
 
-- All classes where the name ends with ```Component```.
-- All classes where the name ends with ```Controller```.
-- All classes that are annotated with the Spring ```@Repository``` annotation.
-- All classes that inherit from ```AbstractComponent```.
+- All classes where the name ends with `Component`.
+- All classes where the name ends with `Controller`.
+- All classes that are annotated with the Spring `@Repository` annotation.
+- All classes that inherit from `AbstractComponent`.
 - etc
 
 ## Basic usage
 
-To use a component finder, simply create an instance of the ```ComponentFinder``` class and configure it as needed.
+To use a component finder, simply create an instance of the `ComponentFinder` class and configure it as needed.
 
 ```java
 Container webApplication = mySoftwareSystem.addContainer("Web Application", "Description", "Apache Tomcat 7.x");
@@ -32,17 +37,18 @@ ComponentFinder componentFinder = new ComponentFinder(
 componentFinder.findComponents();
 ```
 
-In this case, we're going to find components and associate them with the ```webApplication``` container, and we're only going to find components that reside somewhere underneath the ```com.mycompany.mysoftwaresystem``` package to avoid accidentally finding components residing in frameworks that we might be using.
+In this case, we're going to find components and associate them with the `webApplication` container, and we're only going to find components that reside somewhere underneath the `com.mycompany.mysoftwaresystem` package to avoid accidentally finding components residing in frameworks that we might be using.
 
 We also need to plug in one or more component finder strategies, which actually implement the logic to find and extract components from a codebase.
 
 ## Component finder strategies
 
-The are a number of component finder strategies already implemented in this GitHub repository and, since the code is open source, you can build your own too. Some of the component finder strategies work using static analysis and reflection techniques against the compiled version of the code (you will need this on your classpath), others by parsing the source code.
+The are a number of component finder strategies already implemented in this GitHub repository and, since the code is open source, you can build your own too.
+Some of the component finder strategies work using static analysis and reflection techniques against the compiled version of the code (you will need this on your classpath), others by parsing the source code.
 
 Name | Dependency | Description | Extracted from
 ---- | ---------- | ----------- | --------------
-[TypeMatcherComponentFinderStrategy](type-matchers.md) | structurizr-core | A component finder strategy that uses type information to find components, based upon a number of pluggable TypeMatcher implementations (e.g. [NameSuffixTypeMatcher](https://github.com/structurizr/java/blob/master/structurizr-core/src/com/structurizr/analysis/NameSuffixTypeMatcher.java), [ImplementsInterfaceTypeMatcher](https://github.com/structurizr/java/blob/master/structurizr-core/src/com/structurizr/analysis/ImplementsInterfaceTypeMatcher.java), [RegexTypeMatcher](https://github.com/structurizr/java/blob/master/structurizr-core/src/com/structurizr/analysis/RegexTypeMatcher.java) and [AnnotationTypeMatcher](https://github.com/structurizr/java/blob/master/structurizr-core/src/com/structurizr/analysis/AnnotationTypeMatcher.java)). | Compiled bytecode
-[SpringComponentFinderStrategy](spring-component-finder-strategies.md) | structurizr-spring | Finds types annotated ```@Controller```, ```@RestController```, ```@Component```, ```@Service``` and ```@Repository```, plus classes that extend ```JpaRepository```. | Compiled bytecode
-[StructurizrAnnotationsComponentFinderStrategy](structurizr-annotations.md) | structurizr-core | Finds the Structurizr annotations  ```@Component```, ```@UsedByPerson```, ```@UsedBySoftwareSystem```, ```@UsedByContainer```, ```@UsesSoftwareSystem```, ```@UsesContainer``` and ```@UsesComponent```. | Compiled bytecode
+[TypeMatcherComponentFinderStrategy](type-matchers.md) | structurizr-core | A component finder strategy that uses type information to find components, based upon a number of pluggable TypeMatcher implementations (e.g. [NameSuffixTypeMatcher](https://github.com/structurizr/java-extensions/blob/master/structurizr-analysis/src/com/structurizr/analysis/NameSuffixTypeMatcher.java), [ImplementsInterfaceTypeMatcher](https://github.com/structurizr/java-extensions/blob/master/structurizr-analysis/src/com/structurizr/analysis/ImplementsInterfaceTypeMatcher.java), [RegexTypeMatcher](https://github.com/structurizr/java-extensions/blob/master/structurizr-analysis/src/com/structurizr/analysis/RegexTypeMatcher.java) and [AnnotationTypeMatcher](https://github.com/structurizr/java-extensions/blob/master/structurizr-analysis/src/com/structurizr/analysis/AnnotationTypeMatcher.java)). | Compiled bytecode
+[SpringComponentFinderStrategy](spring-component-finder-strategies.md) | structurizr-spring | Finds types annotated `@Controller`, `@RestController`, `@Component`, `@Service` and `@Repository`, plus classes that extend `JpaRepository`. | Compiled bytecode
+[StructurizrAnnotationsComponentFinderStrategy](structurizr-annotations.md) | structurizr-core | Finds the Structurizr annotations  `@Component`, `@UsedByPerson`, `@UsedBySoftwareSystem`, `@UsedByContainer`, `@UsesSoftwareSystem`, `@UsesContainer` and `@UsesComponent`. | Compiled bytecode
 [SourceCodeComponentFinderStrategy](supplementing-from-source-code.md) | structurizr-core | This component finder strategy doesn't really find components, it instead extracts the top-level Javadoc comment from the code so that this can be added to existing component definitions. It also calculates the size of components, based upon the number of lines of source code. | Source code

--- a/docs/spring-component-finder-strategies.md
+++ b/docs/spring-component-finder-strategies.md
@@ -1,30 +1,33 @@
 # Spring component finder strategies
 
-Included in the ```structurizr-spring``` library are a number of component finder strategies that help you identify components in Spring applications, including those built using Spring Boot.
+Included in the `structurizr-spring` library are a number of component finder strategies that help you identify components in Spring applications, including those built using Spring Boot.
 
-* __SpringMvcControllerComponentFinderStrategy__: A component finder strategy that finds Spring MVC controllers (classes annotated ```@Controller```).
-* __SpringRestControllerComponentFinderStrategy__: A component finder strategy that finds Spring REST controllers (classes annotated ```@RestController```).
-* __SpringServiceComponentFinderStrategy__: A component finder strategy that finds Spring services (classes annotated ```@Service```).
-* __SpringComponentComponentFinderStrategy__: A component finder strategy that finds Spring components (classes annotated ```@Component```).
-* __SpringRepositoryComponentFinderStrategy__: A component finder strategy for Spring repositories (classes annotated ```@Repository```, plus those that extend ```JpaRepository``` or ```CrudRepository```).
+* __SpringMvcControllerComponentFinderStrategy__: A component finder strategy that finds Spring MVC controllers (classes annotated `@Controller`).
+* __SpringRestControllerComponentFinderStrategy__: A component finder strategy that finds Spring REST controllers (classes annotated `@RestController`).
+* __SpringServiceComponentFinderStrategy__: A component finder strategy that finds Spring services (classes annotated `@Service`).
+* __SpringComponentComponentFinderStrategy__: A component finder strategy that finds Spring components (classes annotated `@Component`).
+* __SpringRepositoryComponentFinderStrategy__: A component finder strategy for Spring repositories (classes annotated `@Repository`, plus those that extend `JpaRepository` or `CrudRepository`).
 * __SpringComponentFinderStrategy__: A combined component finder strategy that uses all of the individual strategies listed above.
 
 ## Spring naming conventions and interfaces vs implementation classes
 
-Some of the Spring annotations (e.g. ```@Component```, ```@Service``` and ```@Repository```) are typically used to annotate _implementation classes_. For example, a ```JdbcCustomerRepository``` class might be annotated ```@Repository```, rather than the ```CustomerRepository``` interface. This component finder strategy tries to refer to interface types rather than implementation classes, based upon the following assumptions:
+Some of the Spring annotations (e.g. `@Component`, `@Service` and `@Repository`) are typically used to annotate _implementation classes_.
+For example, a `JdbcCustomerRepository` class might be annotated `@Repository`, rather than the `CustomerRepository` interface.
+This component finder strategy tries to refer to interface types rather than implementation classes, based upon the following assumptions:
 
-1. Having a component named ```CustomerRepository``` is preferable to ```JdbcCustomerRespository```.
+1. Having a component named `CustomerRepository` is preferable to `JdbcCustomerRespository`.
 2. Other types in the codebase will likely have a dependency on the interface type (e.g. via dependency injection) rather than being coupled to the implementation class.
 
-Given that a class can implement any number of interfaces, for a given implementation class, the component finder strategies will try to find the interface where the name of that interface is included in the name of the implementation class (i.e. ```*Interface```, ```Interface*``` and ```*Interface*```). For example, the following implementation classes will match an interface named ```CustomerRepository```:
+Given that a class can implement any number of interfaces, for a given implementation class, the component finder strategies will try to find the interface where the name of that interface is included in the name of the implementation class (i.e. `*Interface`, `Interface*` and `*Interface*`).
+For example, the following implementation classes will match an interface named `CustomerRepository`:
 
-* ```JdbcCustomerRepository```
-* ```CustomerRepositoryImpl```
-* ```JdbcCustomerRepositoryImpl```
+* `JdbcCustomerRepository`
+* `CustomerRepositoryImpl`
+* `JdbcCustomerRepositoryImpl`
 
 ## Public vs non-public types
 
-By default, non-public types will be ignored so that, for example, you can hide repository implementations behind services, as described at [Whoops! Where did my architecture go](http://olivergierke.de/2013/01/whoops-where-did-my-architecture-go/). Use the ```setIncludePublicTypesOnly``` method to change this behaviour.
+By default, non-public types will be ignored so that, for example, you can hide repository implementations behind services, as described at [Whoops! Where did my architecture go](http://olivergierke.de/2013/01/whoops-where-did-my-architecture-go/). Use the `setIncludePublicTypesOnly` method to change this behaviour.
 
 ## Example
 

--- a/docs/spring-petclinic.md
+++ b/docs/spring-petclinic.md
@@ -1,10 +1,14 @@
 # The Spring PetClinic example
 
-This is a step-by-step guide to recreating the System Context, Container and Component diagrams from the [Spring PetClinic example](https://structurizr.com/share/1), which are based upon the original version of the application. It assumes that you have working Java, Maven and git installations plus a development environment to write code. The full source code for this example can be found in [SpringPetClinic.java](https://github.com/structurizr/java/blob/master/structurizr-examples/src/com/structurizr/example/SpringPetClinic.java). 
+This is a step-by-step guide to recreating the System Context, Container and Component diagrams from the [Spring PetClinic example](https://structurizr.com/share/1), which are based upon the original version of the application.
+It assumes that you have working Java, Maven and git installations plus a development environment to write code.
+The full source code for this example can be found in
+[SpringPetClinic.java](https://github.com/structurizr/java-extensions/blob/master/structurizr-examples/src/com/structurizr/example/SpringPetClinic.java). 
 
 ## 1. Clone and build the Spring PetClinic code
 
-First of all, we need to download a copy of the [Spring PetClinic source code](https://github.com/spring-projects/spring-petclinic/). Please note that this example was created with a specific version of the Spring PetClinic codebase, so please be sure to perform the ```git checkout``` step too.
+First of all, we need to download a copy of the [Spring PetClinic source code](https://github.com/spring-projects/spring-petclinic/).
+Please note that this example was created with a specific version of the Spring PetClinic codebase, so please be sure to perform the `git checkout` step too.
 
 ```
 git clone https://github.com/spring-projects/spring-petclinic.git
@@ -18,7 +22,8 @@ Next we need to run the build.
 mvn
 ```
 
-The Spring PetClinic is a sample application and includes three persistence implementations (JDBC, JPA and Spring Data) that all do the same thing. As this is unrealistic for most applications, let's make things easier by removing the JPA and Spring Data implementations.
+The Spring PetClinic is a sample application and includes three persistence implementations (JDBC, JPA and Spring Data) that all do the same thing.
+As this is unrealistic for most applications, let's make things easier by removing the JPA and Spring Data implementations.
 
 ```
 rm -r target/spring-petclinic-1.0.0-SNAPSHOT/WEB-INF/classes/org/springframework/samples/petclinic/repository/jpa/
@@ -27,12 +32,14 @@ rm -r target/spring-petclinic-1.0.0-SNAPSHOT/WEB-INF/classes/org/springframework
 
 ## 2. Create a model
 
-With the Spring PetClinic application built, we now need to create a software architecture model using the [extract and supplement](https://structurizr.com/help/extract-and-supplement) approach. We will do this by creating a simple Java program to create the model. The Maven, Gradle, etc dependencies you will need are as follows:
+With the Spring PetClinic application built, we now need to create a software architecture model using the [extract and supplement](https://structurizr.com/help/extract-and-supplement) approach.
+We will do this by creating a simple Java program to create the model.
+The Maven, Gradle, etc dependencies you will need are as follows:
 
-Name                                     | Description
----------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------
-com.structurizr:structurizr-client:1.3.4 | The Structurizr API client library.
-com.structurizr:structurizr-spring:1.3.4 | The Spring component finder.
+Name                                       | Description
+------------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------
+`com.structurizr:structurizr-client:1.3.4` | The Structurizr API client library.
+`com.structurizr:structurizr-spring:1.3.4` | The Spring component finder.
 
 First we need to create a little boilerplate code to create a workspace and a model.
 
@@ -57,7 +64,8 @@ clinicEmployee.uses(springPetClinic, "Uses");
 
 ### 4. Containers
 
-Stepping down to containers, the Spring PetClinic system is made up of a Java web application that uses a database to store data. If we make some assumptions about the deployment technology stack, we can represent this in code as follows.
+Stepping down to containers, the Spring PetClinic system is made up of a Java web application that uses a database to store data.
+If we make some assumptions about the deployment technology stack, we can represent this in code as follows.
 
 ```java
 Container webApplication = springPetClinic.addContainer("Web Application",
@@ -73,9 +81,13 @@ webApplication.uses(relationalDatabase, "Reads from and writes to", "JDBC");
 
 ## 5. Components
 
-At the next level of abstraction, we need to open up the web application to see the components inside it. Although we couldn't really get the two previous levels of abstraction from the codebase easily, we *can* get the components. All we need to do is [understand what a "component" means in the context of this codebase](https://structurizr.com/help/components-vs-classes). We can then use this information to help us find and extract them in order to populate the software architecture model.
+At the next level of abstraction, we need to open up the web application to see the components inside it.
+Although we couldn't really get the two previous levels of abstraction from the codebase easily, we *can* get the components.
+All we need to do is [understand what a "component" means in the context of this codebase](https://structurizr.com/help/components-vs-classes).
+We can then use this information to help us find and extract them in order to populate the software architecture model.
 
-Spring MVC uses Java annotations (```@Controller```, ```@Service``` and ```@Repository```) to signify classes as being web controllers, services and repositories respectively. Assuming that we consider these to be our architecturally significant code elements, it's then a simple job of extracting these annotated classes (Spring Beans) from the codebase.
+Spring MVC uses Java annotations (`@Controller`, `@Service` and `@Repository`) to signify classes as being web controllers, services and repositories respectively.
+Assuming that we consider these to be our architecturally significant code elements, it's then a simple job of extracting these annotated classes (Spring Beans) from the codebase.
 
 ```java
 ComponentFinder componentFinder = new ComponentFinder(
@@ -88,13 +100,18 @@ ComponentFinder componentFinder = new ComponentFinder(
 componentFinder.findComponents();
 ```
 
-The ```SpringComponentFinderStrategy``` is a pre-built component finder strategy that understands how applications are built with Spring and how to identify Spring components, such as MVC controllers, REST controllers, services, repositories, JPA repositories, etc. The way that you identify supporting types (i.e. the Java classes and interfaces) that implement a component is also pluggable. Here, with the ```ReferencedTypesSupportingTypesStrategy```, we're looking for all types directly referenced by the component type(s). See [Components and supporting types](supporting-types.md) for more details about this.
+The `SpringComponentFinderStrategy` is a pre-built component finder strategy that understands how applications are built with Spring and how to identify Spring components, such as MVC controllers, REST controllers, services, repositories, JPA repositories, etc.
+The way that you identify supporting types (i.e. the Java classes and interfaces) that implement a component is also pluggable.
+Here, with the `ReferencedTypesSupportingTypesStrategy`, we're looking for all types directly referenced by the component type(s).
+See [Components and supporting types](supporting-types.md) for more details about this.
 
 Once the components and their supporting types have been identified, the dependencies between components are also identified and extracted.
 
-In addition, the ```SourceCodeComponentFinderStrategy``` will parse the top-level Javadoc comment from the source file for each component type for inclusion in the model. It will also calculate the size of each component based upon the number of lines of source code across all supporting types.
+In addition, the `SourceCodeComponentFinderStrategy` will parse the top-level Javadoc comment from the source file for each component type for inclusion in the model.
+It will also calculate the size of each component based upon the number of lines of source code across all supporting types.
 
-The final thing we need to do is connect the user to the web controllers, and the repositories to the database. This is easy to do since the software architecture model is represented in code.
+The final thing we need to do is connect the user to the web controllers, and the repositories to the database.
+This is easy to do since the software architecture model is represented in code.
 
 ```java
 webApplication.getComponents().stream()
@@ -108,7 +125,9 @@ webApplication.getComponents().stream()
 
 ## 6. Create some views
 
-With the software architecture model in place, we now need to create some views with which to visualise the model. Again, we can do this using code. First the context diagram, which includes all people and all software systems.
+With the software architecture model in place, we now need to create some views with which to visualise the model.
+Again, we can do this using code.
+First the context diagram, which includes all people and all software systems.
 
 ```java
 ViewSet viewSet = workspace.getViews();
@@ -137,18 +156,19 @@ componentView.add(relationalDatabase);
 
 ## 7. Linking elements to external resources
 
-In order to create a set of maps for the Spring PetClinic system that reflect reality, we can link the components on the component diagram to the source code. This isn't necessary, but doing so means that we can [navigate from the diagrams to the code](https://structurizr.com/help/diagram-navigation).
+In order to create a set of maps for the Spring PetClinic system that reflect reality, we can link the components on the component diagram to the source code.
+This isn't necessary, but doing so means that we can [navigate from the diagrams to the code](https://structurizr.com/help/diagram-navigation).
  
 ```java
 for (Component component : webApplication.getComponents()) {
-	for (CodeElement codeElement : component.getCode()) {
-    	String sourcePath = codeElement.getUrl();
-       	if (sourcePath != null) {
-           	codeElement.setUrl(sourcePath.replace(
-               	sourceRoot.toURI().toString(),
-               	"https://github.com/spring-projects/spring-petclinic/tree/864580702f8ef4d2cdfd7fe4497fb8c9e86018d2/"));
-		}
-	}
+    for (CodeElement codeElement : component.getCode()) {
+        String sourcePath = codeElement.getUrl();
+        if (sourcePath != null) {
+            codeElement.setUrl(sourcePath.replace(
+                sourceRoot.toURI().toString(),
+                "https://github.com/spring-projects/spring-petclinic/tree/864580702f8ef4d2cdfd7fe4497fb8c9e86018d2/"));
+        }
+    }
 }
 ```
 
@@ -160,7 +180,8 @@ relationalDatabase.setUrl("https://github.com/spring-projects/spring-petclinic/t
 
 ## 8. Styling the diagrams
 
-By default, Structurizr will render all of the elements as grey boxes. However, the elements and relationships can be styled.
+By default, Structurizr will render all of the elements as grey boxes.
+However, the elements and relationships can be styled.
 
 ```java
 springPetClinic.addTags("Spring PetClinic");
@@ -184,7 +205,9 @@ styles.addElementStyle("Spring Repository").background("#95D46C").color("#000000
 
 ## 9. Upload the model and views to Structurizr
 
-The code we've just seen simply creates an in-memory representation of the software architecture model, in this case as a collection of Java objects. The open source Structurizr for Java library also includes a way to export this model to an intermediate JSON representation, which can then be imported into some tooling that is able to visualise it. This is what Structurizr does.
+The code we've just seen simply creates an in-memory representation of the software architecture model, in this case as a collection of Java objects.
+The open source Structurizr for Java library also includes a way to export this model to an intermediate JSON representation, which can then be imported into some tooling that is able to visualise it.
+This is what Structurizr does.
 
 ```java
 StructurizrClient structurizrClient = new StructurizrClient("key", "secret");
@@ -205,14 +228,16 @@ If you sign in to Structurizr and open the workspace you just uploaded, you'll s
 
 ![The Spring PetClinic workspace](images/spring-petclinic-1.png)
 
-Structurizr doesn't do any automatic layout of the elements on your diagrams, so you will need to drag the boxes around to create a layout that you like. Here are the links to the live example diagrams:
+Structurizr doesn't do any automatic layout of the elements on your diagrams, so you will need to drag the boxes around to create a layout that you like.
+Here are the links to the live example diagrams:
 
 - [System Context diagram](https://structurizr.com/share/1#context)
 - [Container diagram](https://structurizr.com/share/1#containers)
 - [Component diagram](https://structurizr.com/share/1#components)
 
 ## 11. Explore the model
-Once you have a model of your software system, you can explore it using a number of different visualisations. For example:
+Once you have a model of your software system, you can explore it using a number of different visualisations.
+For example:
 
 - [Static structure, rendered as a tree](https://structurizr.com/share/1/explore/tree)
 - [Static structure, rendered as circles based upon size](https://structurizr.com/share/1/explore/size-circles)

--- a/docs/structurizr-annotations.md
+++ b/docs/structurizr-annotations.md
@@ -1,19 +1,23 @@
 # Structurizr annotations
 
-Structurizr for Java includes some custom annotations that you can add to your code. These serve to either make it explicit how components should be extracted from your codebase, or they help supplement the software architecture model.
+Structurizr for Java includes some custom annotations that you can add to your code.
+These serve to either make it explicit how components should be extracted from your codebase, or they help supplement the software architecture model.
 
-The annotations can be found in the [structurizr-annotations](https://bintray.com/structurizr/maven/structurizr-java) artifact, which is a very small standalone JAR file containing only the Structurizr annotations. All annotations have a runtime retention policy, so they will be present in the compiled bytecode.
+The annotations can be found in the [structurizr-annotations](https://bintray.com/structurizr/maven/structurizr-java) artifact, which is a very small standalone JAR file containing only the Structurizr annotations.
+All annotations have a runtime retention policy, so they will be present in the compiled bytecode.
 
 ## @Component
 
-A type-level annotation that can be used to signify that the annotated type (an interface or class) can be considered to be a "component". The properties are as follows:
+A type-level annotation that can be used to signify that the annotated type (an interface or class) can be considered to be a "component".
+The properties are as follows:
 
 - description: The description of the component (optional).
 - technology: The technology of component (optional).
 
 ## @UsedByPerson
 
-A type-level annotation that can be used to signify that the named person uses the component on which this annotation is placed, creating a relationship form the person to the component. The properties are as follows:
+A type-level annotation that can be used to signify that the named person uses the component on which this annotation is placed, creating a relationship form the person to the component.
+The properties are as follows:
 
 - name: The name of the person (required).
 - description: The description of the relationship (optional).
@@ -21,7 +25,8 @@ A type-level annotation that can be used to signify that the named person uses t
 
 ## @UsedBySoftwareSystem
 
-A type-level annotation that can be used to signify that the named software system uses the component on which this annotation is placed, creating a relationship from the software system to the component. The properties are as follows:
+A type-level annotation that can be used to signify that the named software system uses the component on which this annotation is placed, creating a relationship from the software system to the component.
+The properties are as follows:
 
 - name: The name of the software system (required).
 - description: The description of the relationship (optional).
@@ -29,17 +34,20 @@ A type-level annotation that can be used to signify that the named software syst
 
 ## @UsedByContainer
 
-A type-level annotation that can be used to signify that the named container uses the component on which this annotation is placed, creating a relationship from the container to the component. The properties are as follows:
+A type-level annotation that can be used to signify that the named container uses the component on which this annotation is placed, creating a relationship from the container to the component.
+The properties are as follows:
 
 - name: The name of the container (required).
 - description: The description of the relationship (optional).
 - technology: The technology of relationship (optional).
 
-If the container resides in the same software system as the component, the simple name can be used to identify the container (e.g. "Database"). Otherwise, the full canonical name of the form "Software System/Container" must be used (e.g. "Some Other Software System/Database").
+If the container resides in the same software system as the component, the simple name can be used to identify the container (e.g. "Database").
+Otherwise, the full canonical name of the form "Software System/Container" must be used (e.g. "Some Other Software System/Database").
 
 ## @UsesSoftwareSystem
 
-A type-level annotation that can be used to signify that the component on which this annotation is placed has a relationship to the named software system, creating a relationship from the component to the software system. The properties are as follows:
+A type-level annotation that can be used to signify that the component on which this annotation is placed has a relationship to the named software system, creating a relationship from the component to the software system.
+The properties are as follows:
 
 - name: The name of the software system (required).
 - description: The description of the relationship (optional).
@@ -47,19 +55,23 @@ A type-level annotation that can be used to signify that the component on which 
 
 ## @UsesContainer
 
-A type-level annotation that can be used to signify that the component on which this annotation is placed has a relationship to the named container, creating a relationship from the component to the container. The properties are as follows:
+A type-level annotation that can be used to signify that the component on which this annotation is placed has a relationship to the named container, creating a relationship from the component to the container.
+The properties are as follows:
 
 - name: The name of the container (required).
 - description: The description of the relationship (optional).
 - technology: The technology of relationship (optional).
 
-If the container resides in the same software system as the component, the simple name can be used to identify the container (e.g. "Database"). Otherwise, the full canonical name of the form "Software System/Container" must be used (e.g. "Some Other Software System/Database").
+If the container resides in the same software system as the component, the simple name can be used to identify the container (e.g. "Database").
+Otherwise, the full canonical name of the form "Software System/Container" must be used (e.g. "Some Other Software System/Database").
 
 ## @UsesComponent
 
 A field-level annotation that can be used to supplement the existing relationship (i.e. add a description and/or technology) between two components.
 
-When using the various component finder strategies, Structurizr for Java will identify components along with the relationships between those components. Since this is typically done using reflection against the compiled bytecode, you'll notice that the description and technology properties of the resulting relationships is always empty. The ```@UsesComponent``` annotation provides a simple way to ensure that such information is added into the model.
+When using the various component finder strategies, Structurizr for Java will identify components along with the relationships between those components.
+Since this is typically done using reflection against the compiled bytecode, you'll notice that the description and technology properties of the resulting relationships is always empty.
+The `@UsesComponent` annotation provides a simple way to ensure that such information is added into the model.
 
 The properties are as follows:
 
@@ -103,4 +115,5 @@ class JdbcRepository implements Repository {
 }
 ```
 
-See [StructurizrAnnotations.java](https://github.com/structurizr/java/blob/master/structurizr-examples/src/com/structurizr/example/StructurizrAnnotations.java) for the full source code illustrating how to use the various annotations in conjunction with the component finder. The resulting diagrams can be found at [https://structurizr.com/share/36571](https://structurizr.com/share/36571).
+See [StructurizrAnnotations.java](https://github.com/structurizr/java-extensions/blob/master/structurizr-examples/src/com/structurizr/example/StructurizrAnnotations.java) for the full source code illustrating how to use the various annotations in conjunction with the component finder.
+The resulting diagrams can be found at [https://structurizr.com/share/36571](https://structurizr.com/share/36571).

--- a/docs/supplementing-from-source-code.md
+++ b/docs/supplementing-from-source-code.md
@@ -1,15 +1,17 @@
 # Supplementing the model from source code
 
-Most of the component finder strategies included in Structurizr for Java find components using reflection against the compiled bytecode. Some useful information exists in the source code though; including:
+Most of the component finder strategies included in Structurizr for Java find components using reflection against the compiled bytecode.
+Some useful information exists in the source code though; including:
 
-* The type-level doc comment (```/** ... */```, typically extracted using the javadoc tool). This can be used to populate the description property of components.
+* The type-level doc comment (`/** ... */`, typically extracted using the javadoc tool). This can be used to populate the description property of components.
 * The number of lines of source code. This can be a used to calculate the "size" of a component.
 
-A pre-built [SourceCodeComponentFinderStrategy](https://github.com/structurizr/java/blob/master/structurizr-core/src/com/structurizr/analysis/SourceCodeComponentFinderStrategy.java) is provided to do this, which uses the standard ```javadoc``` tool. You will need to include ```JAVA_HOME/lib/tools.jar``` on your classpath.
+A pre-built [SourceCodeComponentFinderStrategy](https://github.com/structurizr/java-extensions/blob/master/structurizr-analysis/src/com/structurizr/analysis/SourceCodeComponentFinderStrategy.java) is provided to do this, which uses the standard `javadoc` tool.
+You will need to include `JAVA_HOME/lib/tools.jar` on your classpath.
 
 ## Example
 
-Here's an example of how to use the ```SourceCodeComponentFinderStrategy```, taken from the [Spring PetClinic example](spring-petclinic.md).
+Here's an example of how to use the `SourceCodeComponentFinderStrategy`, taken from the [Spring PetClinic example](spring-petclinic.md).
 
 ```java
 File sourceRoot = new File("/some/path");
@@ -24,9 +26,9 @@ ComponentFinder componentFinder = new ComponentFinder(
 componentFinder.findComponents();
 ```
 
-For every ```CodeElement``` that belongs to every ```Component``` in the ```Container```  passed to the ```ComponentFinder```, the ```SourceCodeComponentFinderStrategy``` will:
+For every `CodeElement` that belongs to every `Component` in the `Container`  passed to the `ComponentFinder`, the `SourceCodeComponentFinderStrategy` will:
 
 * Set the description property, based on the type-level doc comment. The doc comment will be truncated if necessary (e.g. to 150 characters in the example above).
-* Set the size property to be the number of lines of the file that the type was found in. 
+* Set the size property to be the number of lines of the file that the type was found in.
 
-Additionally, the description property of the ```Component``` will be set to be that of the primary ```CodeElement```, if a description has not been set on the ```Component``` already. 
+Additionally, the description property of the `Component` will be set to be that of the primary `CodeElement`, if a description has not been set on the `Component` already. 

--- a/docs/supporting-types.md
+++ b/docs/supporting-types.md
@@ -2,7 +2,8 @@
 
 In Structurizr, a [Component](https://github.com/structurizr/java/blob/master/structurizr-core/src/com/structurizr/model/Component.java) is described by a number of properties and can have a number of [CodeElement](https://github.com/structurizr/java/blob/master/structurizr-core/src/com/structurizr/model/CodeElement.java)s associated with it that represent the Java classes and interfaces that implement and/or support that component.
 
-Because each codebase is different, the mechanism to find a component's supporting types is pluggable via a number of strategies ([SupportingTypesStrategy](https://github.com/structurizr/java/blob/master/structurizr-core/src/com/structurizr/analysis/SupportingTypesStrategy.java)), which can be used in combination. Let's look at the [Spring PetClinic example](spring-petclinic.md) to see how the various supporting types strategies affect the software architecture model.
+Because each codebase is different, the mechanism to find a component's supporting types is pluggable via a number of strategies ([SupportingTypesStrategy](https://github.com/structurizr/java-extensions/blob/master/structurizr-analysis/src/com/structurizr/analysis/SupportingTypesStrategy.java)), which can be used in combination.
+Let's look at the [Spring PetClinic example](spring-petclinic.md) to see how the various supporting types strategies affect the software architecture model.
 
 ## 1. No supporting types strategy
 
@@ -17,13 +18,16 @@ ComponentFinder componentFinder = new ComponentFinder(
 componentFinder.findComponents();
 ```
 
-When executed against the compiled version of the Spring PetClinic codebase, each component identified will be made up of only the types found by the component finder strategy. For example, the ```VisitRepository``` component will be made up of an interface (```VisitRepository```) and the implementation class (```JdbcVisitRepositoryImpl```). You can visualise this using [Structurizr's tree exploration](https://structurizr.com/help/explorations).
+When executed against the compiled version of the Spring PetClinic codebase, each component identified will be made up of only the types found by the component finder strategy.
+For example, the `VisitRepository` component will be made up of an interface (`VisitRepository`) and the implementation class (`JdbcVisitRepositoryImpl`).
+You can visualise this using [Structurizr's tree exploration](https://structurizr.com/help/explorations).
 
 ![](images/supporting-types-1.png)
  
 ## 2. Referenced types in the same package
 
-Next, let's use the [ReferencedTypesInSamePackageSupportingTypesStrategy](https://github.com/structurizr/java/blob/master/structurizr-core/src/com/structurizr/analysis/ReferencedTypesInSamePackageSupportingTypesStrategy.java) to find all supporting types in the same package as the component type. This is particularly useful when each component neatly resides in its own Java package, and you aren't interested in any other code outside of this package.
+Next, let's use the [ReferencedTypesInSamePackageSupportingTypesStrategy](https://github.com/structurizr/java-extensions/blob/master/structurizr-analysis/src/com/structurizr/analysis/ReferencedTypesInSamePackageSupportingTypesStrategy.java) to find all supporting types in the same package as the component type.
+This is particularly useful when each component neatly resides in its own Java package, and you aren't interested in any other code outside of this package.
 
 ```java
 ComponentFinder componentFinder = new ComponentFinder(
@@ -36,13 +40,14 @@ ComponentFinder componentFinder = new ComponentFinder(
 componentFinder.findComponents();
 ```
 
-This strategy finds all of the supporting types that are referenced by the types found by the component finder strategy. In real terms, we've now additionally picked up the ```JdbcVisitRowMapper``` class, since this is used by the ```JdbcVisitRepositoryImpl``` class.
+This strategy finds all of the supporting types that are referenced by the types found by the component finder strategy.
+In real terms, we've now additionally picked up the `JdbcVisitRowMapper` class, since this is used by the `JdbcVisitRepositoryImpl` class.
 
 ![](images/supporting-types-2.png)
 
 ## 3. All referenced types
 
-Next, let's use the [ReferencedTypesSupportingTypesStrategy](https://github.com/structurizr/java/blob/master/structurizr-core/src/com/structurizr/analysis/ReferencedTypesSupportingTypesStrategy.java) to find all of the referenced types, irrespective of which package they reside in, provided that package sits somewhere underneath ```org.springframework.samples.petclinic```.
+Next, let's use the [ReferencedTypesSupportingTypesStrategy](https://github.com/structurizr/java-extensions/blob/master/structurizr-analysis/src/com/structurizr/analysis/ReferencedTypesSupportingTypesStrategy.java) to find all of the referenced types, irrespective of which package they reside in, provided that package sits somewhere underneath `org.springframework.samples.petclinic`.
 
 ```java
 ComponentFinder componentFinder = new ComponentFinder(
@@ -55,21 +60,25 @@ ComponentFinder componentFinder = new ComponentFinder(
 componentFinder.findComponents();
 ```
 
-As the following image illustrates, we now have many more classes that are supporting the implementation of the ```VisitRepository``` component.
+As the following image illustrates, we now have many more classes that are supporting the implementation of the `VisitRepository` component.
 
 ![](images/supporting-types-3.png)
 
-This collection of classes may look confusing at first, but the ```JdbcVisitRepositoryImpl``` class references the ```Visit``` class, which in turn references the ```Pet``` class, which in turn references the ```Owner``` class, etc. The Structurizr tree exploration shows that these classes are shared between the ```VisitRepository``` and other components by rendering their names in grey.
+This collection of classes may look confusing at first, but the `JdbcVisitRepositoryImpl` class references the `Visit` class, which in turn references the `Pet` class, which in turn references the `Owner` class, etc.
+The Structurizr tree exploration shows that these classes are shared between the `VisitRepository` and other components by rendering their names in grey.
 
 ## 4. Directly referenced types only
 
-Of course, the ```JdbcVisitRepositoryImpl``` class may not actually use all of these classes, but they are certainly available to it. This is one of the drawbacks of using static analysis based upon compiled bytecode. You can modify this behaviour and find only those types directly referenced by the component by passing ```false``` to the constructor of the [ReferencedTypesSupportingTypesStrategy](https://github.com/structurizr/java/blob/master/structurizr-core/src/com/structurizr/analysis/ReferencedTypesSupportingTypesStrategy.java).
+Of course, the `JdbcVisitRepositoryImpl` class may not actually use all of these classes, but they are certainly available to it.
+This is one of the drawbacks of using static analysis based upon compiled bytecode.
+You can modify this behaviour and find only those types directly referenced by the component by passing `false` to the constructor of the [ReferencedTypesSupportingTypesStrategy](https://github.com/structurizr/java-extensions/blob/master/structurizr-analysis/src/com/structurizr/analysis/ReferencedTypesSupportingTypesStrategy.java).
 
 ![](images/supporting-types-4.png)
 
 ## Excluding types
 
-The Structurizr ```ComponentFinder``` will also allow you to exclude types from the component scanning process using one or more regular expressions. If we wanted to exclude the ```BaseEntity``` and ```NamedEntity``` classes in one of the previous examples, we could add the following line of code before calling ```componentFinder.findComponents()```.
+The Structurizr `ComponentFinder` will also allow you to exclude types from the component scanning process using one or more regular expressions.
+If we wanted to exclude the `BaseEntity` and `NamedEntity` classes in one of the previous examples, we could add the following line of code before calling `componentFinder.findComponents()`.
 
 ```
 componentFinder.exclude("org\\.springframework\\.samples\\.petclinic\\.model\\..*Entity");
@@ -81,15 +90,19 @@ The result is as follows.
 
 ## Type erasure
 
-The implementation of the various supporting types strategies above use reflection based upon Java bytecode. For this reason, the results are subject to the rules around Java's [type erasure](https://docs.oracle.com/javase/tutorial/java/generics/erasure.html). For example, if you have a component that references ```Collection<Customer>``` in method signatures, you may find ```Customer``` missing from the list of supporting types.
+The implementation of the various supporting types strategies above use reflection based upon Java bytecode. For this reason, the results are subject to the rules around Java's [type erasure](https://docs.oracle.com/javase/tutorial/java/generics/erasure.html).
+For example, if you have a component that references `Collection<Customer>` in method signatures, you may find `Customer` missing from the list of supporting types.
 
 ## Visualising shared code
 
-The easiest way to analyse the component-code relationships is to visualise them. Structurizr has a number of built-in explorations that can help with this.
+The easiest way to analyse the component-code relationships is to visualise them.
+Structurizr has a number of built-in explorations that can help with this.
 
 ### Component size
 
-[Structurizr's component size exploration](https://structurizr.com/share/1/explore/size-circles) renders components and code elements as a collection of nested circles, where the size of each circle is based upon the number of lines of code. Shared code elements are rendered using a different style, and hovering the mouse over a shared code element will highlight all other occurrences. This allows you to easily see where code elements (interfaces and classes) are shared between components.
+[Structurizr's component size exploration](https://structurizr.com/share/1/explore/size-circles) renders components and code elements as a collection of nested circles, where the size of each circle is based upon the number of lines of code.
+Shared code elements are rendered using a different style, and hovering the mouse over a shared code element will highlight all other occurrences.
+This allows you to easily see where code elements (interfaces and classes) are shared between components.
 
 ![](images/supporting-types-6.gif)
 

--- a/docs/type-matchers.md
+++ b/docs/type-matchers.md
@@ -1,10 +1,10 @@
 # Type matchers
 
-Structurizr for Java includes a number "type matchers", which when used in conjunction with the [TypeMatcherComponentFinderStrategy](https://github.com/structurizr/java/blob/master/structurizr-core/src/com/structurizr/analysis/TypeMatcherComponentFinderStrategy.java), provides a simple way to find components in your codebase based upon specific types. The following pre-built type matchers are included.
+Structurizr for Java includes a number "type matchers", which when used in conjunction with the [TypeMatcherComponentFinderStrategy](https://github.com/structurizr/java-extensions/blob/master/structurizr-analysis/src/com/structurizr/analysis/TypeMatcherComponentFinderStrategy.java), provides a simple way to find components in your codebase based upon specific types. The following pre-built type matchers are included.
 
 ## NameSuffixTypeMatcher
 
-Matches types where the (simple) name of the type ends with the specified suffix. For example, to find all types named ```*Controller```:
+Matches types where the (simple) name of the type ends with the specified suffix. For example, to find all types named `*Controller`:
 
 ```java
 new NameSuffixTypeMatcher("Controller", "", "");
@@ -12,7 +12,7 @@ new NameSuffixTypeMatcher("Controller", "", "");
 
 ## RegexTypeMatcher
 
-Matches types using a regex against the fully qualified type name. For example, to find all types with a fully qualified name of ```*.web.*Controller```:
+Matches types using a regex against the fully qualified type name. For example, to find all types with a fully qualified name of `*.web.*Controller`:
 
 ```java
 new RegexTypeMatcher(".*\.web\..*Controller", "", "");
@@ -20,7 +20,7 @@ new RegexTypeMatcher(".*\.web\..*Controller", "", "");
 
 ## AnnotationTypeMatcher
 
-Matches types based upon the presence of a type-level annotation. For example, to find all types that are annotated with the Java EE ```@Stateless``` annotation:
+Matches types based upon the presence of a type-level annotation. For example, to find all types that are annotated with the Java EE `@Stateless` annotation:
 
 ```java
 new AnnotationTypeMatcher(javax.ejb.Stateless.class, "", "");
@@ -28,7 +28,7 @@ new AnnotationTypeMatcher(javax.ejb.Stateless.class, "", "");
 
 ## ImplementsInterfaceTypeMatcher
 
-Matches types where the type implements the specified interface. For example, to find all types that implement the ```Repository``` interface:
+Matches types where the type implements the specified interface. For example, to find all types that implement the `Repository` interface:
 
 ```java
 new ImplementsInterfaceTypeMatcher(Repository.class, "", "");
@@ -36,7 +36,7 @@ new ImplementsInterfaceTypeMatcher(Repository.class, "", "");
 
 ## ExtendsClassTypeMatcher
 
-Matches types where the type extends the specified class. For example, to find all types that extend the ```AbstractComponent``` class:
+Matches types where the type extends the specified class. For example, to find all types that extend the `AbstractComponent` class:
 
 ```java
 new ExtendsClassTypeMatcher(AbstractComponent.class, "", "");
@@ -58,8 +58,8 @@ ComponentFinder componentFinder = new ComponentFinder(
 componentFinder.findComponents();
 ```
 
-The description and technology properties specified on the type matchers will be used to set the corresponding properties on the ```Component``` instances that are created when matching types are found.
+The description and technology properties specified on the type matchers will be used to set the corresponding properties on the `Component` instances that are created when matching types are found.
 
 ## Writing your own type matchers
 
-You can write your own type matchers by implementing the [TypeMatcher](https://github.com/structurizr/java/blob/master/structurizr-core/src/com/structurizr/analysis/TypeMatcher.java) interface, or by extending the [AbstractTypeMatcher](https://github.com/structurizr/java/blob/master/structurizr-core/src/com/structurizr/analysis/AbstractTypeMatcher.java) class.
+You can write your own type matchers by implementing the [TypeMatcher](https://github.com/structurizr/java-extensions/blob/master/structurizr-analysis/src/com/structurizr/analysis/TypeMatcher.java) interface, or by extending the [AbstractTypeMatcher](https://github.com/structurizr/java-extensions/blob/master/structurizr-analysis/src/com/structurizr/analysis/AbstractTypeMatcher.java) class.


### PR DESCRIPTION
Some of the links to the source code were broken since the migration of parts of the code from the `structurizr-core` to `structurizr-analysis`.
This PR fixes these links and improves the touched files in the following ways:
- Replace inline `````` blocks with `` which render equally
- Split paragraphs along their individual sentences to improve maintainability by providing better diffs in the future
- Replace all tabs with spaces
