### PR TITLE
Fix output stream reset in finally block …

### DIFF
--- a/structurizr-analysis/src/com/structurizr/analysis/SourceCodeComponentFinderStrategy.java
+++ b/structurizr-analysis/src/com/structurizr/analysis/SourceCodeComponentFinderStrategy.java
@@ -136,7 +136,7 @@ public class SourceCodeComponentFinderStrategy implements ComponentFinderStrateg
         }
         finally {
             System.setOut(outOriginal);
-            System.setOut(errOriginal);
+            System.setErr(errOriginal);
         }
     }
 


### PR DESCRIPTION
…in SourceCodeComponentFinderStrategy.

When running ComponentFinder.findComponents() over more than one source root and thereby including SourceCodeComponentFinderStrategy twice logging stops working entirely. If only run once, only error-output stops working. 
It turned out this is because this finally block sets the _System.out_ twice, last time with the _errOriginal_ holding the original System.err output stream:
```       
        finally {
            System.setOut(outOriginal);
            System.setOut(errOriginal);
        }
```
 I understand the purpose with this code being to reset the original state of the two output streams.